### PR TITLE
Formatting README

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,16 +7,14 @@ This fork adds some new features and corrects some deprecated functions.
 
 Tested with ~Julia 1.5.0~.
 
-* QuickStart
+** QuickStart
 #+begin_src julia
 julia> using Fuzzy
 #+end_src
 
-### Mamdani FIS
-
-- Create input, output membership functions and rules
-
-```julia
+*** Mamdani FIS
+Create input, output membership functions and rules
+#+begin_src julia
 julia> input_a = Dict("small" => TriangularMF(1, 2, 3), "large" => TriangularMF(4, 5, 6))
 julia> input_b = Dict("small" => TriangularMF(1, 2, 3))
 
@@ -25,20 +23,18 @@ julia> output = Dict("small" => TriangularMF(1, 2, 3))
 
 julia> rule = Rule(["large", "small"], "small")
 julia> rules = [rule]
-```
+#+end_src
 
-- Create FIS
-
-```julia
+Create FIS
+#+begin_src julia
 julia> fis = FISMamdani(inputs, output, rules)
-```
+#+end_src
 
-- Find output
-
-```julia
+Find output
+#+begin_src julia
 julia> in_vals = [4.7, 2.3]
 julia> eval_fis(fis, in_vals)
-```
+#+end_src
 
 ### Sugeno FIS
 

--- a/README.org
+++ b/README.org
@@ -36,11 +36,10 @@ julia> in_vals = [4.7, 2.3]
 julia> eval_fis(fis, in_vals)
 #+end_src
 
-### Sugeno FIS
+*** Sugeno FIS
 
-- Create input membership functions and rules with consequence coefficients
-
-```julia
+Create input membership functions and rules with consequence coefficients
+#+begin_src julia
 julia> input_a = Dict("small" => TriangularMF(1, 2, 3), "large" => TriangularMF(5, 6, 7))
 julia> input_b = Dict("small" => TriangularMF(1, 2, 3))
 
@@ -49,22 +48,20 @@ julia> inputs = [input_a, input_b]
 julia> rule1 = Rule(["large", "small"], [1.0, 1.0, 1.0])
 julia> rule2 = Rule(["small", "small"], [0.0, 0.0, 5.0])
 julia> rules = [rule]
-```
+#+end_src
 
-- Create FIS
-
-```julia
+Create FIS
+#+begin_src julia
 julia> fis = FISSugeno(inputs, rules)
-```
+#+end_src
 
-- Find output
-
-```julia
+Find output
+#+begin_src julia
 julia> in_vals = [2.3, 1.2]
 julia> eval_fis(fis, in_vals)
-```
+#+end_src
 
-## Features
+** Features
 
 - FIS
 
@@ -83,7 +80,7 @@ julia> eval_fis(fis, in_vals)
 
   - Mean of Maximum
   - Weighted Average (default)
-  - _Centroid (coming soon)_
+  - /Centroid (coming soon)/
 
 - T-Norm
 
@@ -103,6 +100,6 @@ julia> eval_fis(fis, in_vals)
   - Einstein sum (E-SUM)
   - Hamacher sum (H-SUM)
 
-## License
+** License
 
 MIT

--- a/README.org
+++ b/README.org
@@ -1,17 +1,16 @@
-# Fuzzy EAFIT Fork
+* Fuzzy EAFIT Fork
 
 Mamdani and Sugeno type Fuzzy Inference System in julia. This code is a fork of
-[Phelipe](https://github.com/phelipe/Fuzzy.jl).
+[[https://github.com/phelipe/Fuzzy.jl][Phelipe]].
 
 This fork adds some new features and corrects some deprecated functions.
 
-Tested with Julia 1.5.0.
+Tested with ~Julia 1.5.0~.
 
-## QuickStart
-
-```julia
+* QuickStart
+#+begin_src julia
 julia> using Fuzzy
-```
+#+end_src
 
 ### Mamdani FIS
 


### PR DESCRIPTION
Changed formatting of README from the standard markdown, to an org mode file.

This allows easy and faster manipulation from Emacs, with a same result.